### PR TITLE
Compare with `dqrng::dqsample`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,1 +1,4 @@
 ^README\.Rmd$
+^.*\.Rproj$
+^\.Rproj\.user$
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,10 @@
 Package: rademacher
-Title: What the Package Does (One Line, Title Case)
-Version: 0.0.0.9000
+Title: Very fast Random Sampling from the Rademacher Distribution
+Version: 0.1
 Authors@R: 
-    person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
-           comment = c(ORCID = "YOUR-ORCID-ID"))
-Description: What the package does (one paragraph).
-License: `use_mit_license()`, `use_gpl3_license()` or friends to pick a
-    license
+    person("Kyle", "Butts")
+Description: Very fast draws from the rademacher distribution
+License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
@@ -14,3 +12,5 @@ LinkingTo:
     Rcpp
 Imports: 
     Rcpp
+Suggests: 
+    dqrng

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,8 @@ Package: rademacher
 Title: Very fast Random Sampling from the Rademacher Distribution
 Version: 0.1
 Authors@R: 
-    person("Kyle", "Butts")
+        person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
+           comment = c(ORCID = "YOUR-ORCID-ID"))
 Description: Very fast draws from the rademacher distribution
 License: MIT + file LICENSE
 Encoding: UTF-8

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2023
+COPYRIGHT HOLDER: rademacher authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2023 rademacher authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.Rmd
+++ b/README.Rmd
@@ -40,14 +40,18 @@ devtools::install_github("kylebutts/rademacher")
 
 ```{r benchmark}
 library(rademacher)
+library(dqrng)
 library(bench)
 
-# 1,000,000 draws is ~ 13x as fast
+# 1,000,000 draws is ~ 13x as fast as stats::runif, 25x as fast as stats::sample, 3x as fast as dqrng::dqsample
 n = 1e7
 bench::mark(
   runif_rademacher  = (runif(n) > 0.5) * 2 - 1,
   sample_rademacher = sample_rademacher(n),
-  check = FALSE
+  samp = sample(x = c(1, -1), size = n, replace = TRUE),
+  dqsamp = dqsample(x = c(1,-1), size = n, replace = TRUE),
+  check = FALSE, 
+  iterations = 3
 )
 
 # 1000 draws is ~ 4.5x as fast

--- a/README.md
+++ b/README.md
@@ -32,22 +32,28 @@ devtools::install_github("kylebutts/rademacher")
 
 ``` r
 library(rademacher)
+library(dqrng)
 library(bench)
+#> Warning: package 'bench' was built under R version 4.2.2
 
-# 1,000,000 draws is ~ 13x as fast
+# 1,000,000 draws is ~ 13x as fast as stats::runif, 25x as fast as stats::sample, 3x as fast as dqrng::dqsample
 n = 1e7
 bench::mark(
   runif_rademacher  = (runif(n) > 0.5) * 2 - 1,
   sample_rademacher = sample_rademacher(n),
-  check = FALSE
+  samp = sample(x = c(1, -1), size = n, replace = TRUE),
+  dqsamp = dqsample(x = c(1,-1), size = n, replace = TRUE),
+  check = FALSE, 
+  iterations = 3
 )
-#> Warning: Some expressions had a GC in every iteration; so filtering is
-#> disabled.
-#> # A tibble: 2 × 6
+#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
+#> # A tibble: 4 × 6
 #>   expression             min   median `itr/sec` mem_alloc `gc/sec`
 #>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-#> 1 runif_rademacher   93.62ms 103.57ms      9.46   190.7MB     18.9
-#> 2 sample_rademacher   6.47ms   7.41ms    117.      39.4MB     35.6
+#> 1 runif_rademacher     600ms 664.69ms     1.49    190.7MB    2.48 
+#> 2 sample_rademacher   39.9ms  45.66ms    22.6      39.4MB    0    
+#> 3 samp               842.6ms    1.08s     0.921   114.5MB    0.921
+#> 4 dqsamp              97.1ms 127.45ms     7.65    114.5MB    2.55
 
 # 1000 draws is ~ 4.5x as fast
 n = 1000
@@ -59,8 +65,8 @@ bench::mark(
 #> # A tibble: 2 × 6
 #>   expression             min   median `itr/sec` mem_alloc `gc/sec`
 #>   <bch:expr>        <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
-#> 1 runif_rademacher    8.16µs  10.33µs    92669.   22.16KB     18.5
-#> 2 sample_rademacher   1.15µs   1.56µs   525800.    6.62KB      0
+#> 1 runif_rademacher    52.4µs   87.5µs     7601.   22.16KB     0   
+#> 2 sample_rademacher    5.1µs      9µs    51497.    6.62KB     5.15
 ```
 
 This is totally open source. You can copy and past to your package


### PR DESCRIPTION
I just ran the benchmark against `dqrng::dqsample`, and your algorithm is indeed around 3x faster and requires 3x less memory (quite important for some larger problems with`fwildclusterboot`). Super cool stuff! I'll definitely add it to `fwildclusterboot` =) 

This PR updates the readme with benchmarks against `dqrng::dqsample`, `stats::sample`, adds `dqrng` to suggests and roxygenises the packages. I have also added an MIT license. 